### PR TITLE
Remove psycopg2 from sandbox requirements

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,3 @@
 Django>=1.11,<1.12
 wagtail>=1.10,<1.11
-psycopg2
 -e .[docs,test]


### PR DESCRIPTION
The sandbox's `settings.py` specifies `django.db.backends.sqlite3`.