### PR TITLE
Simplify saving/retrieving user segments

### DIFF
--- a/src/wagtail_personalisation/adapters.py
+++ b/src/wagtail_personalisation/adapters.py
@@ -98,8 +98,12 @@ class SessionSegmentsAdapter(BaseSegmentsAdapter):
         return [segments[pk] for pk in segment_ids if pk in segments]
 
     def set_segments(self, segments):
-        """Set the currently active segments"""
+        """Set the currently active segments
 
+        :param segments: The segments to set for the current request
+        :type segments: list of wagtail_personalisation.models.Segment
+
+        """
         serialized_segments = []
         segment_ids = set()
         for segment in segments:

--- a/src/wagtail_personalisation/adapters.py
+++ b/src/wagtail_personalisation/adapters.py
@@ -201,8 +201,7 @@ class SessionSegmentsAdapter(BaseSegmentsAdapter):
             if result:
                 additional_segments.append(segment)
 
-        new_segments = current_segments + additional_segments
-        self.set_segments(new_segments)
+        self.set_segments(current_segments + additional_segments)
         self.update_visit_count()
 
 

--- a/src/wagtail_personalisation/wagtail_hooks.py
+++ b/src/wagtail_personalisation/wagtail_hooks.py
@@ -74,15 +74,7 @@ def serve_variation(page, request, serve_args, serve_kwargs):
     """
     user_segments = []
     adapter = get_segment_adapter(request)
-
-    for segment in adapter.get_segments():
-        try:
-            user_segment = Segment.objects.get(
-                pk=segment['id'], status=Segment.STATUS_ENABLED)
-        except Segment.DoesNotExist:
-            user_segment = None
-        if user_segment:
-            user_segments.append(user_segment)
+    user_segments = adapter.get_segments()
 
     if len(user_segments) > 0:
         variations = _check_for_variations(user_segments, page)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 from wagtail.wagtailcore.models import Page, Site
-from wagtail_factories import SiteFactory
-from tests.factories.page import PageFactory
 
 pytest_plugins = [
     'tests.fixtures'
@@ -16,4 +14,3 @@ def django_db_setup(django_db_setup, django_db_blocker):
         # Remove some initial data that is brought by the sandbox module
         Site.objects.all().delete()
         Page.objects.all().exclude(depth=1).delete()
-

--- a/tests/factories/segment.py
+++ b/tests/factories/segment.py
@@ -7,7 +7,7 @@ from wagtail_personalisation import models
 
 class SegmentFactory(factory.DjangoModelFactory):
     name = 'TestSegment'
-    status = 'enabled'
+    status = models.Segment.STATUS_ENABLED
 
     class Meta:
         model = models.Segment

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,9 @@
 import pytest
 
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.backends.db import SessionStore
+from django.test.client import RequestFactory as BaseRequestFactory
 from tests.factories.page import PageFactory
 from tests.factories.segment import SegmentFactory
 from tests.factories.site import SiteFactory
@@ -18,3 +22,19 @@ def segmented_page(site):
     page = PageFactory(parent=site.root_page)
     segment = SegmentFactory()
     return page.copy_for_segment(segment)
+
+
+@pytest.fixture()
+def rf():
+    """RequestFactory instance"""
+    return RequestFactory()
+
+
+class RequestFactory(BaseRequestFactory):
+
+    def request(self, user=None, **request):
+        request = super(RequestFactory, self).request(**request)
+        request.user = AnonymousUser()
+        request.session = SessionStore()
+        request._messages = FallbackStorage(request)
+        return request

--- a/tests/unit/test_adapter_session.py
+++ b/tests/unit/test_adapter_session.py
@@ -1,0 +1,35 @@
+import pytest
+
+from wagtail_personalisation import adapters
+from tests.factories.segment import SegmentFactory
+
+
+@pytest.mark.django_db
+def test_get_segments(rf, monkeypatch):
+    request = rf.get('/')
+
+    adapter = adapters.SessionSegmentsAdapter(request)
+
+    segment_1 = SegmentFactory(name='segment-1', persistent=True)
+    segment_2 = SegmentFactory(name='segment-2', persistent=True)
+
+    adapter.set_segments([segment_1, segment_2])
+    assert len(request.session['segments']) == 2
+
+    segments = adapter.get_segments()
+    assert segments == [segment_1, segment_2]
+
+
+@pytest.mark.django_db
+def test_get_segment_by_id(rf, monkeypatch):
+    request = rf.get('/')
+
+    adapter = adapters.SessionSegmentsAdapter(request)
+
+    segment_1 = SegmentFactory(name='segment-1', persistent=True)
+    segment_2 = SegmentFactory(name='segment-2', persistent=True)
+
+    adapter.set_segments([segment_1, segment_2])
+
+    segment_x = adapter.get_segment_by_id(segment_2.pk)
+    assert segment_x == segment_2


### PR DESCRIPTION
This changes makes sure that Adapter.get_segments() always return Segment instances and Adapter.set_segments() access segment instances