### PR TITLE
Change reverse path - Django 1.9 compatibility

### DIFF
--- a/src/wagtail_personalisation/views.py
+++ b/src/wagtail_personalisation/views.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
 from django import forms
+from django.core.urlresolvers import reverse
 from django.http import HttpResponseForbidden, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, reverse
+from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.contrib.modeladmin.views import IndexView


### PR DESCRIPTION
`django.shortcuts.reverse` does not exist in Django 1.9 so the package currently does not work on that version. Sandbox does not output any deprecation notices so seems okay to use that import for Django 1.11 too.