### PR TITLE
Use older migration dependencies - Compatiility with Wagtail 1.9

### DIFF
--- a/src/wagtail_personalisation/migrations/0001_initial.py
+++ b/src/wagtail_personalisation/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('wagtailcore', '0030_index_on_pagerevision_created_at'),
+        ('wagtailcore', '0001_initial'),
     ]
 
     operations = [

--- a/src/wagtail_personalisation/migrations/0011_personalisablepagemetadata.py
+++ b/src/wagtail_personalisation/migrations/0011_personalisablepagemetadata.py
@@ -9,7 +9,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('wagtailcore', '0033_remove_golive_expiry_help_text'),
+        ('wagtailcore', '0001_initial'),
         ('wagtail_personalisation', '0010_auto_20170531_1101'),
     ]
 


### PR DESCRIPTION
Currently I cannot migrate on Wagtail 1.9 because the migrations used in dependencies do not exist there. Since we depend on the `Page` model only in those migrations it seems fine to me to just use the `0001_initial` migration that creates that model.